### PR TITLE
Fix flaky runit startup race in Go e2e preview builds

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -10,12 +10,13 @@ services:
       init:
         - apk update
         - apk add --no-cache --virtual .build-deps runit bash gcc musl-dev openssl go
-        - mkdir -p /etc/service/server
-        - cp "${TUGBOAT_ROOT}/.tugboat/runit/server/run" /etc/service/server/run
-        - chmod +x /etc/service/server/run
       update:
         - echo "********** UPDATE **********"
       build:
         - echo "********** BUILD **********"
         - cd ${TUGBOAT_ROOT}/server && go build -o server .
+        - mkdir -p /etc/service/server
+        - cp "${TUGBOAT_ROOT}/.tugboat/runit/server/run" /etc/service/server/run
+        - chmod +x /etc/service/server/run
+        - sv restart server || sv up server || true
         - cat .tugboat/tugboat.txt

--- a/.tugboat/runit/server/run
+++ b/.tugboat/runit/server/run
@@ -1,7 +1,8 @@
 #!/bin/sh
-# Runit service script for the Go WebSocket server
+# Runit service script for the Go server
 # This script runs the server in the foreground
 # Runit will automatically restart it if it crashes
 
-cd "${TUGBOAT_ROOT}/server"
+cd "${TUGBOAT_ROOT}/server" || exit 1
+while [ ! -x ./server ]; do sleep 1; done
 exec ./server

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,3 @@
 module tugboat-test
 
-go 1.24.3
+go 1.23


### PR DESCRIPTION
## Summary
- Register the runit service after `go build` so `./server` exists before exec
- Harden the run script to wait for the binary before starting
- Align `go.mod` with Alpine's Go 1.23 toolchain
- Restart the service after rebuilds with `sv restart`

## Test plan
- [ ] Rebuild Tugboat preview from this branch
- [ ] Confirm `e2e-test-setup` passes without `./server: not found` errors
- [ ] Verify endpoints respond (not 404)

Made with [Cursor](https://cursor.com)