### PR TITLE
Harden Go build for Tugboat alpine previews

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -9,12 +9,13 @@ services:
     commands:
       init:
         - apk update
-        - apk add --no-cache --virtual .build-deps runit bash gcc musl-dev openssl go
+        - apk add --no-cache runit bash gcc musl-dev openssl go
       update:
         - echo "********** UPDATE **********"
       build:
         - echo "********** BUILD **********"
-        - cd ${TUGBOAT_ROOT}/server && go build -o server .
+        - command -v go >/dev/null 2>&1 || apk add --no-cache go gcc musl-dev
+        - cd "${TUGBOAT_ROOT}/server" && GOTOOLCHAIN=local go build -o server .
         - mkdir -p /etc/service/server
         - cp "${TUGBOAT_ROOT}/.tugboat/runit/server/run" /etc/service/server/run
         - chmod +x /etc/service/server/run


### PR DESCRIPTION
## Summary
- Install `go` as a regular apk package (not `--virtual .build-deps`) so it is not purged before later build/start steps
- Re-install `go` in `build` if missing (covers refresh-only previews that skip `init`)
- Use `GOTOOLCHAIN=local` so `go build` uses Alpine's compiler instead of trying to download a newer toolchain

## Context
Fixes `Exit code: 1; Command: cd ${TUGBOAT_ROOT}/server && go build -o server .` during preview setup.

## Test plan
- [ ] Rebuild `e2e-query-params-go` preview from scratch
- [ ] Confirm `go build` succeeds in build logs
- [ ] Confirm endpoints respond after preview is online

Made with [Cursor](https://cursor.com)