### PR TITLE
Pin alpine image and log Go version before build

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,6 +1,6 @@
 services:
   go:
-    image: tugboatqa/alpine
+    image: tugboatqa/alpine:3.21
     aliases: test
     http: true
     https: false
@@ -14,7 +14,8 @@ services:
         - echo "********** UPDATE **********"
       build:
         - echo "********** BUILD **********"
-        - cd ${TUGBOAT_ROOT}/server && go build -o server .
+        - go version
+        - cd "${TUGBOAT_ROOT}/server" && go build -o server .
         - mkdir -p /etc/service/server
         - cp "${TUGBOAT_ROOT}/.tugboat/runit/server/run" /etc/service/server/run
         - chmod +x /etc/service/server/run


### PR DESCRIPTION
## Summary
- Pin service image to `tugboatqa/alpine:3.21` for a consistent Go toolchain across builders
- Log `go version` during build to make toolchain mismatch failures easy to diagnose

## Context
Unpinned `tugboatqa/alpine` can resolve to different Alpine/Go versions depending on each builder host's cached `latest` image. With Alpine's `GOTOOLCHAIN=local`, `go build` exits 1 when `go.mod` requires a newer Go than the builder has installed.

## Test plan
- [ ] Rebuild preview from this branch
- [ ] Confirm build log shows `go version go1.23.x`
- [ ] Confirm `go build` succeeds and endpoints respond

Made with [Cursor](https://cursor.com)